### PR TITLE
Travis quiet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - virtualenv ~/.venv
   - source ~/.venv/bin/activate
   - pip install -q numpy scipy
+  - pip install -q git+https://github.com/optimizers/pysparse.git
   - pip install -q git+https://github.com/PythonOptimizers/pykrylov.git@develop
   - pip install -q algopy
   - pip install -q git+https://github.com/b45ch1/pycppad.git


### PR DESCRIPTION
Less verbose build to not overflow TravisCI and install PySparse. The tests run more or less as intended now.
